### PR TITLE
Addresses duplicated main tags on some pages

### DIFF
--- a/wp-content/themes/thepoliticalsage/templates/content-page.php
+++ b/wp-content/themes/thepoliticalsage/templates/content-page.php
@@ -1,15 +1,15 @@
-<main class="page responsive-text">
+<section class="page responsive-text">
     <section class="text-wrapper">
         <div class="letterhead">
-            <i class="fa fa-star star"></i> 
-            <i class="fa fa-star star"></i> 
-            <i class="fa fa-star star"></i> 
-            <img src="<?php echo get_template_directory_uri(); ?>/assets/images/button.svg" alt="TPR Logo"> 
-            <i class="fa fa-star star"></i> 
-            <i class="fa fa-star star"></i> 
+            <i class="fa fa-star star"></i>
+            <i class="fa fa-star star"></i>
+            <i class="fa fa-star star"></i>
+            <img src="<?php echo get_template_directory_uri(); ?>/assets/images/button.svg" alt="TPR Logo">
+            <i class="fa fa-star star"></i>
+            <i class="fa fa-star star"></i>
             <i class="fa fa-star star"></i>
         </div>
         <?php the_content(); ?>
     </section>
-</main>
+</section>
 <?php wp_link_pages(['before' => '<nav class="page-nav"><p>' . __('Pages:', 'sage'), 'after' => '</p></nav>']); ?>


### PR DESCRIPTION
  - Ideally I would remove the lone opening tag from the header file
    and the lone closing tag from the footer file, but it seems most
    pages are depending on those.